### PR TITLE
Update README.md to include the missing t on Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ First, clone the repository using SSH or HTTPS, e.g. `git clone https://github.c
 
 - [Typescript](https://www.typescriptlang.org/).
 
-- [WXT](https://wxt.dev/): It is a framework for web extensions. We use this framework mainly because it allows us to develop the extension with React+Typescrip and to facilitate the packaging and deployment of the extension for all websites (mainly Firefox, Chrome and Safari).
+- [WXT](https://wxt.dev/): It is a framework for web extensions. We use this framework mainly because it allows us to develop the extension with React+Typescript and to facilitate the packaging and deployment of the extension for all websites (mainly Firefox, Chrome and Safari).
 
 - [React](https://react.dev/).
 


### PR DESCRIPTION
Including the missing t on the end of the word "typescrip"