### PR TITLE
[PB-6526]:fix/connect/disconnect no longer reloads tabs or logs users out

### DIFF
--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { browser } from 'wxt/browser'
 
-import { clearProxySettings, reloadTabsAfterConnect } from './proxy.service'
+import { clearProxySettings } from './proxy.service'
 import { ConnectionDetails } from '../components/ConnectionDetails'
 import { VpnStatus } from '../components/VpnStatus'
 import { Footer } from '../components/Footer'
@@ -128,7 +128,6 @@ export const App = () => {
     setUserData(userData)
     await storageService.saveVpnStatus('ON', userData)
     setStatus('ON')
-    await reloadTabsAfterConnect()
   }
 
   const onDisconnectVpn = async () => {

--- a/src/entrypoints/popup/proxy.service.ts
+++ b/src/entrypoints/popup/proxy.service.ts
@@ -7,19 +7,6 @@ const VPN_CONFIG = {
 
 const IS_FIREFOX = import.meta.env.BROWSER === 'firefox'
 
-async function clearProxyCache() {
-  browser.browsingData.remove({}, { cookies: true })
-}
-
-async function reloadAllTabsBypassingCache() {
-  const tabs = await browser.tabs.query({})
-  await Promise.all(
-    tabs
-      .filter((tab) => tab.id !== undefined && !tab.url?.startsWith('about:'))
-      .map((tab) => browser.tabs.reload(tab.id!, { bypassCache: true })),
-  )
-}
-
 export async function updateProxySettings() {
   if (IS_FIREFOX) {
     await browser.storage.local.set({ vpnEnabled: true })
@@ -44,18 +31,9 @@ export async function updateProxySettings() {
   await browser.proxy.settings.set({ value: proxyConfig, scope: 'regular' })
 }
 
-export async function reloadTabsAfterConnect() {
-  if (IS_FIREFOX) {
-    await reloadAllTabsBypassingCache()
-    return
-  }
-  await browser.tabs.reload()
-}
-
 export async function clearProxySettings() {
   if (IS_FIREFOX) {
     await browser.storage.local.set({ vpnEnabled: false })
-    clearProxyCache()
     if (browser.webRequest.handlerBehaviorChanged) {
       await browser.webRequest.handlerBehaviorChanged()
     }
@@ -66,9 +44,5 @@ export async function clearProxySettings() {
     mode: 'system' as const,
   }
 
-  browser.proxy.settings
-    .set({ value: proxyConfig, scope: 'regular' })
-    .then(() => {
-      clearProxyCache()
-    })
+  await browser.proxy.settings.set({ value: proxyConfig, scope: 'regular' })
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,37 +8,49 @@ export default defineConfig({
   modules: ['@wxt-dev/i18n/module'],
   srcDir: 'src',
   manifest: ({ browser }) => ({
-    name: 'Internxt VPN - Free, Encrypted & Unlimited VPN',
-    short_name: 'Internxt VPN',
-    default_locale: 'en',
-    version: '1.4.0',
-    description:
-      'Internxt free VPN for Chrome: an encrypted, secure VPN built to protect your privacy.',
-    icons: {
-      '16': 'icon/16.png',
-      '48': 'icon/48.png',
-      '128': 'icon/128.png',
-      '192': 'icon/192.png',
-      '512': 'icon/512.png',
+  name: 'Internxt VPN',
+  short_name: 'Internxt VPN',
+  default_locale: 'en',
+  version: '1.4.0',
+  description:
+    'Internxt free VPN: an encrypted, secure VPN built to protect your privacy.',
+  icons: {
+    '16': 'icon/16.png',
+    '48': 'icon/48.png',
+    '128': 'icon/128.png',
+    '192': 'icon/192.png',
+    '512': 'icon/512.png',
+  },
+  permissions: [
+    'storage',
+    'proxy',
+    'webRequest',
+    ...(browser === 'firefox'
+      ? ['webRequestBlocking']
+      : ['webRequestAuthProvider']),
+  ],
+  ...(browser === 'firefox'
+    ? {
+        browser_specific_settings: {
+          gecko: {
+            id: 'hello@internxt.com',       
+            strict_min_version: '91.1.0',
+            data_collection_permissions: {
+              required: ['none'],
+            },
+          },
+        },
+      }
+    : {}),
+  web_accessible_resources: [
+    {
+      resources: ['index.html'],
+      matches: ['<all_urls>'],
     },
-    permissions: [
-      'storage',
-      'proxy',
-      'webRequest',
-      ...(browser === 'firefox'
-        ? ['webRequestBlocking']
-        : ['webRequestAuthProvider']),
-      'browsingData',
-    ],
-    web_accessible_resources: [
-      {
-        resources: ['index.html'],
-        matches: ['<all_urls>'],
-      },
-    ],
-    host_permissions: ['<all_urls>'],
-    action: {
-      default_popup: 'index.html',
-    },
-  }),
+  ],
+  host_permissions: ['<all_urls>'],
+  action: {
+    default_popup: 'index.html',
+  },
+}),
 })


### PR DESCRIPTION
### Problem

Users reported that the extension reloaded every open tab and logged them out of all websites when toggling the VPN.

### Changes
- Remove cookie clearing: dropped clearProxyCache() and both its calls. Switching the proxy has nothing to do with cookies. Active sessions are now preserved.
- Remove tab reloading: dropped reloadAllTabsBypassingCache() / reloadTabsAfterConnect() and its call in App.tsx. New requests already route through the tunnel automatically
- Drop unused browsingData permission from the manifest.

### Behavior after the fix
Connecting, disconnecting and switching server location all happen without reloading tabs and without dropping any website session.