### PR TITLE
[PB-6526]:fix/vpn location switch connection reuse

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -139,6 +139,7 @@ export default defineBackground(() => {
           port: VPN_PORT,
           username: localCache.connection ?? 'FR',
           password: localCache.token ?? '',
+          connectionIsolationKey: localCache.connection ?? 'FR',
         }
       },
       { urls: ['<all_urls>'] },


### PR DESCRIPTION
In QA, we identified an issue where the IP address was not correctly updating the number it displayed when switching connections, now when changing the VPN location in Firefox, the browser could reuse the TCP socket that had already been authenticated with the previous country, so traffic continued to go through the old node even though the credentials sent were those of the new country. A `connectionIsolationKey` (linked to the selected location) is added to the `ProxyInfo` in `proxy.onRequest` to force a new connection.